### PR TITLE
Missing-APIs

### DIFF
--- a/Shared/BrainCloudAuthentication.hh
+++ b/Shared/BrainCloudAuthentication.hh
@@ -158,6 +158,20 @@ extern NSString *const AUTH_FACEBOOK;
          errorCompletionBlock:(BCErrorCompletionBlock)errorCompletionBlock
                      cbObject:(BCCallbackObject)cbObject;
 
+/**
+ * Get server version.
+ * 
+ * Service Name - Authentication
+ * Service Operation - GET_SERVER_VERSION
+ * 
+ * @param completionBlock Block to call on return of successful server response
+* @param errorCompletionBlock Block to call on return of unsuccessful server response
+* @param cbObject User object sent to the completion blocks
+ */
+- (void)getServerVersion:(BCCompletionBlock)completionBlock
+    errorCompletionBlock:(BCErrorCompletionBlock)errorCompletionBlock
+                cbObject:(BCCallbackObject)cbObject;
+
 
 /**
 * A generic Authenticate method that translates to the same as calling a specific one, except it takes an extraJson

--- a/Shared/BrainCloudAuthentication.mm
+++ b/Shared/BrainCloudAuthentication.mm
@@ -128,6 +128,13 @@
         [password cStringUsingEncoding:NSUTF8StringEncoding], forceCreate, brainCloudCallback);
 }
 
+- (void)getServerVersion:(BCCompletionBlock)completionBlock
+    errorCompletionBlock:(BCErrorCompletionBlock)errorCompletionBlock
+                cbObject:(BCCallbackObject)cbObject
+{
+    _client->getAuthenticationService()->getServerVersion(new BrainCloudCallback(completionBlock, errorCompletionBlock, cbObject));
+}
+
 - (void)authenticateAdvanced:(AuthenticationTypeObjc *)authenticationType
            authenticationIds:(AuthenticationIdsObjc *)authenticationIds
                  forceCreate:(BOOL)forceCreate

--- a/Shared/BrainCloudEvent.hh
+++ b/Shared/BrainCloudEvent.hh
@@ -51,6 +51,23 @@
                 cbObject:(BCCallbackObject)cbObject;
 
 /**
+ * Sends an event to multiple users with the attached json data.
+ * 
+ * Service Name - Event
+ * Service Operation - SEND_EVENT_TO_PROFILES
+ * 
+ * @param toIds The profile ids of the users to send the event
+ * @param eventType The user-defined type of the event
+ * @param eventData The user-defined data for this event encoded in JSON
+ */
+- (void)sendEventToProfiles:(NSArray *)toIds
+                  eventType:(NSString *)eventType
+                  eventData:(NSString *)eventData
+            completionBlock:(BCCompletionBlock)cb
+       errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                   cbObject:(BCCallbackObject)cbObject;
+
+/**
 * Updates an event in the player's incoming event mailbox.
 *
 * Service Name - event

--- a/Shared/BrainCloudEvent.mm
+++ b/Shared/BrainCloudEvent.mm
@@ -43,6 +43,16 @@
         new BrainCloudCallback(cb, ecb, cbObject));
 }
 
+-(void)sendEventToProfiles:(NSArray *)toIds
+                 eventType:(NSString *)eventType
+                 eventData:(NSString *)eventData
+           completionBlock:(BCCompletionBlock)cb
+      errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                  cbObject:(BCCallbackObject)cbObject
+{
+    _client->getEventService()->sendEventToProfiles(TypeHelpers::NSStringArrayToVector(toIds), [eventType UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+}
+
 - (void)updateIncomingEventData:(NSString *)evId
                   jsonEventData:(NSString *)eventData
                 completionBlock:(BCCompletionBlock)cb

--- a/Shared/BrainCloudEvent.mm
+++ b/Shared/BrainCloudEvent.mm
@@ -50,7 +50,7 @@
       errorCompletionBlock:(BCErrorCompletionBlock)ecb
                   cbObject:(BCCallbackObject)cbObject
 {
-    _client->getEventService()->sendEventToProfiles(TypeHelpers::NSStringArrayToVector(toIds), [eventType UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+    _client->getEventService()->sendEventToProfiles(TypeHelpers::NSStringArrayToVector(toIds), [eventType UTF8String], [eventData UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
 }
 
 - (void)updateIncomingEventData:(NSString *)evId

--- a/Shared/BrainCloudFriend.hh
+++ b/Shared/BrainCloudFriend.hh
@@ -41,6 +41,24 @@
                            cbObject:(BCCallbackObject)cbObject;
 
 /**
+ * Retrieves profile information for the specified user. Silently fails, if profile does not exist, just returns null and success, instead of an error.
+ *
+ * Service Name - friend
+ * Service Operation - GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS
+ *
+ * @param externalId The users's external ID
+ * @param authenticationType The authentication type of the user ID
+ * @param completionBlock Block to call on return of successful server response
+ * @param errorCompletionBlock Block to call on return of unsuccessful server response
+ * @param cbObject User object sent to the completion blocks
+ */
+- (void)getProfileInfoForCredentialIfExists:(NSString *)externalId
+                 authenticationType:(AuthenticationTypeObjc *)authenticationType
+                    completionBlock:(BCCompletionBlock)cb
+               errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                           cbObject:(BCCallbackObject)cbObject;
+
+/**
  * Retrieves profile information for the specified external auth user.
  *
  * Service Name - friend

--- a/Shared/BrainCloudFriend.hh
+++ b/Shared/BrainCloudFriend.hh
@@ -75,6 +75,24 @@
                         completionBlock:(BCCompletionBlock)cb
                    errorCompletionBlock:(BCErrorCompletionBlock)ecb
                                cbObject:(BCCallbackObject)cbObject;
+                               
+/**
+ * Retrieves profile information for the specified external auth user.
+ *
+ * Service Name - Friend
+ * Service Operation - GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS
+ *
+ * @param externalId External ID of the user to find
+ * @param externalAuthType The external authentication type used for this user's external ID
+ * @param completionBlock Block to call on return of successful server response
+ * @param errorCompletionBlock Block to call on return of unsuccessful server response
+ * @param cbObject User object sent to the completion blocks
+ */
+- (void)getProfileInfoForExternalAuthIdIfExists:(NSString *)externalId
+                       externalAuthType:(NSString *)externalAuthType
+                        completionBlock:(BCCompletionBlock)cb
+                   errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                               cbObject:(BCCallbackObject)cbObject;
 
 /**
  * Returns user state of a particular user.

--- a/Shared/BrainCloudFriend.mm
+++ b/Shared/BrainCloudFriend.mm
@@ -46,6 +46,16 @@
         [externalId UTF8String], BrainCloud::AuthenticationType::fromString([[authenticationType toString] UTF8String]), new BrainCloudCallback(cb, ecb, cbObject));
 }
 
+- (void)getProfileInfoForCredentialIfExists:(NSString *)externalId
+                 authenticationType:(AuthenticationTypeObjc *)authenticationType
+                    completionBlock:(BCCompletionBlock)cb
+               errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                           cbObject:(BCCallbackObject)cbObject
+{
+    _client->getFriendService()->getProfileInfoForCredentialIfExists(
+        [externalId UTF8String], BrainCloud::AuthenticationType::fromString([[authenticationType toString] UTF8String]), new BrainCloudCallback(cb, ecb, cbObject));
+}
+
 - (void)getProfileInfoForExternalAuthId:(NSString *)externalId
                       externalAuthType:(NSString *)externalAuthType
                         completionBlock:(BCCompletionBlock)cb

--- a/Shared/BrainCloudFriend.mm
+++ b/Shared/BrainCloudFriend.mm
@@ -66,6 +66,16 @@
         [externalId UTF8String], [externalAuthType UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
 }
 
+- (void)getProfileInfoForExternalAuthIdIfExists:(NSString *)externalId
+                      externalAuthType:(NSString *)externalAuthType
+                        completionBlock:(BCCompletionBlock)cb
+                   errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                               cbObject:(BCCallbackObject)cbObject
+{
+    _client->getFriendService()->getProfileInfoForExternalAuthIdIfExists(
+        [externalId UTF8String], [externalAuthType UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+}
+
 - (void)getExternalIdForProfileId:(NSString *)profileId
                authenticationType:(NSString *)authenticationType
                   completionBlock:(BCCompletionBlock)cb

--- a/Shared/BrainCloudGroup.hh
+++ b/Shared/BrainCloudGroup.hh
@@ -645,6 +645,26 @@ typedef NS_ENUM(NSUInteger, AutoJoinStrategy) { JoinFirstGroup, JoinRandomGroup 
                cbObject:(BCCallbackObject)cbObject;
 
 /**
+ * Update the acl settings for a group entity, enforcing ownership.
+ * 
+ * Service Name - Group
+ * Service Operation - UPDATE_GROUP_ENTITY_ACL
+ * 
+ * @param groupId ID of the group
+ * @param entityId The id of the entity to update
+ * @param acl The group's access control list. A null ACL implies default
+ * @param completionBlock Block to call on return of successful server response
+ * @param errorCompletionBlock Block to call on return of unsuccessful server response
+ * @param cbObject User object sent to the completion blocks
+ */
+- (void)updateGroupEntityAcl:(NSString *)groupId
+              entityId:(NSString *)entityId
+                   acl:(NSString *)acl
+       completionBlock:(BCCompletionBlock)cb
+  errorCompletionBlock:(BCErrorCompletionBlock)ecb
+              cbObject:(BCCallbackObject)cbObject;
+
+/**
  * Update a group entity.
  *
  * Service Name - group
@@ -728,6 +748,24 @@ typedef NS_ENUM(NSUInteger, AutoJoinStrategy) { JoinFirstGroup, JoinRandomGroup 
      completionBlock:(BCCompletionBlock)cb
 errorCompletionBlock:(BCErrorCompletionBlock)ecb
             cbObject:(BCCallbackObject)cbObject;
+
+/**
+ * Set a group's access conditions.
+ * 
+ * Service Name - Group
+ * Service Operation - UPDATE_GROUP_ACL
+ * 
+ * @param groupId ID of the group
+ * @param acl The group's access control list. A null ACL implies default
+ * @param completionBlock Block to call on return of successful server response
+ * @param errorCompletionBlock Block to call on return of unsuccessful server response
+ * @param cbObject User object sent to the completion blocks
+ */
+- (void)updateGroupAcl:(NSString *)groupId
+                   acl:(NSString *)acl
+       completionBlock:(BCCompletionBlock)cb
+  errorCompletionBlock:(BCErrorCompletionBlock)ecb
+              cbObject:(BCCallbackObject)cbObject;
 
 /**
  * Update a group's summary data

--- a/Shared/BrainCloudGroup.mm
+++ b/Shared/BrainCloudGroup.mm
@@ -365,6 +365,17 @@
         [groupId UTF8String], version, [jsonData UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
 }
 
+- (void)updateGroupEntityAcl:(NSString *)groupId
+                    entityId:(NSString *)entityId
+                         acl:(NSString *)acl
+             completionBlock:(BCCompletionBlock)cb
+        errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                    cbObject:(BCCallbackObject)cbObject;
+{
+    _client->getGroupService()->updateGroupEntityAcl(
+        [groupId UTF8String], [entityId UTF8String], [acl UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+}
+
 - (void)updateGroupEntityData:(NSString *)groupId
                      entityId:(NSString *)entityId
                       version:(int32_t)version
@@ -409,6 +420,16 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
 {
     _client->getGroupService()->setGroupOpen(
          [groupId UTF8String], isOpenGroup, new BrainCloudCallback(cb, ecb, cbObject));
+}
+
+- (void)updateGroupAcl:(NSString *)groupId
+                   acl:(NSString *)acl
+       completionBlock:(BCCompletionBlock)cb
+  errorCompletionBlock:(BCErrorCompletionBlock)ecb
+              cbObject:(BCCallbackObject)cbObject;
+{
+    _client->getGroupService()->updateGroupAcl(
+        [groupId UTF8String], [acl UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
 }
 
 - (void)updateGroupSummaryData:(NSString *)groupId

--- a/Shared/BrainCloudIdentity.hh
+++ b/Shared/BrainCloudIdentity.hh
@@ -958,6 +958,21 @@
                 cbObject:(BCCallbackObject)cbObject;
 
 /**
+ * Retrieves identity status for given identity type for this profile.
+ * 
+ * Service Name - Identity
+ * Service Operation - GET_IDENTITY_STATUS
+ * 
+ * @param authenticationType Type of authentication
+ * @param externalAuthName The name of the external authentication mechanism (optional, used for custom authentication types)
+ */
+- (void)getIdentityStatus:(AuthenticationTypeObjc *)type
+         externalAuthName:(NSString *)externalAuthName
+          completionBlock:(BCCompletionBlock)cb
+     errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                 cbObject:(BCCallbackObject)cbObject;
+
+/**
 * Retrieve list of expired identities
 *
 * Service Name - Identity

--- a/Shared/BrainCloudIdentity.mm
+++ b/Shared/BrainCloudIdentity.mm
@@ -511,6 +511,16 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
         new BrainCloudCallback(cb, ecb, cbObject));
 }
 
+- (void)getIdentityStatus:(AuthenticationTypeObjc *)type
+         externalAuthName:(NSString *)externalAuthName
+          completionBlock:(BCCompletionBlock)cb
+     errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                 cbObject:(BCCallbackObject)cbObject
+{
+    _client->getIdentityService()->getIdentityStatus(BrainCloud::AuthenticationType::fromString([[type toString] UTF8String]),
+        [externalAuthName UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+}
+
 - (void)getExpiredIdentities:(BCCompletionBlock)cb
         errorCompletionBlock:(BCErrorCompletionBlock)ecb
                     cbObject:(BCCallbackObject)cbObject

--- a/Shared/BrainCloudLeaderboard.hh
+++ b/Shared/BrainCloudLeaderboard.hh
@@ -726,6 +726,31 @@ typedef NS_ENUM(NSUInteger, SortOrder) { HIGH_TO_LOW, LOW_TO_HIGH };
                                  cbObject:(BCCallbackObject)cbObject;
 
 /**
+ * Post the group's score to the given social leaderboard, dynamically creating the group leaderboard if it does not exist yet.
+ * To create new leaderboard, configJson must specify leaderboardType, rotationType, resetAt, and retainedCount, at a minimum, with support to optionally specify an expiry in minutes.
+ *
+ * Service Name - Leaderboard
+ * Service Operation - POST_GROUP_SCORE_DYNAMIC_USING_CONFIG
+ *
+ * @param leaderboardId The leaderboard to post to
+ * @param groupId The id of the group
+ * @param score A score to post
+ * @param scoreData Optional user-defined data to post with the score.
+ * @param configJson Configuration for the leaderboard if it does not exist yet, specified as JSON object. The supporting configuration fields are listed in the following table of configJson fields.
+ * @param completionBlock Block to call on return of successful server response
+ * @param errorCompletionBlock Block to call on return of unsuccessful server response
+ * @param cbObject User object sent to the completion blocks
+ */
+- (void)postScoreToDynamicGroupLeaderboardUsingConfig:(NSString *)leaderboardId
+                                              groupId:(NSString *)groupId
+                                                score:(int)score
+                                            scoreData:(NSString *)scoreData
+                                           configJson:(NSString *)configJson
+                                      completionBlock:(BCCompletionBlock)cb
+                                 errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                                             cbObject:(BCCallbackObject)cbObject;
+
+/**
  * Removes a player's score from the leaderboard
  *
  * Service Name - leaderboard

--- a/Shared/BrainCloudLeaderboard.mm
+++ b/Shared/BrainCloudLeaderboard.mm
@@ -347,6 +347,18 @@
         rotationResetUTC, retainedCount, numDaysToRotate, new BrainCloudCallback(cb, ecb, cbObject));
 }
 
+- (void)postScoreToDynamicGroupLeaderboardUsingConfig:(NSString *)leaderboardId
+                                              groupId:(NSString *)groupId
+                                                score:(int)score
+                                            scoreData:(NSString *)scoreData
+                                           configJson:(NSString *)configJson
+                                      completionBlock:(BCCompletionBlock)cb
+                                 errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                                             cbObject:(BCCallbackObject)cbObject
+{
+    _client->getLeaderboardService()->postScoreToDynamicGroupLeaderboardUsingConfig([leaderboardId UTF8String], [groupId UTF8String], score, [scoreData UTF8String], [configJson UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+}
+
 - (void)removePlayerScore:(NSString *)leaderboardId
                 versionId:(int)versionId
           completionBlock:(BCCompletionBlock)cb

--- a/Shared/BrainCloudLobby.hh
+++ b/Shared/BrainCloudLobby.hh
@@ -417,7 +417,6 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
                     cbObject:(BCCallbackObject)cbObject;
 
 //Cancels this members find, join and search for lobbies
-//available when rtt is supported.
 - (void)cancelFindRequest:(NSString *)lobbyId
                   entryId:(NSString *)entryId
           completionBlock:(BCCompletionBlock)cb

--- a/Shared/BrainCloudLobby.hh
+++ b/Shared/BrainCloudLobby.hh
@@ -418,10 +418,11 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
 
 //Cancels this members find, join and search for lobbies
 //available when rtt is supported.
-//- (void)cancelFindRequest:(NSString *)lobbyId
-//          completionBlock:(BCCompletionBlock)cb
-//     errorCompletionBlock:(BCErrorCompletionBlock)ecb
-//                 cbObject:(BCCallbackObject)cbObject;
+- (void)cancelFindRequest:(NSString *)lobbyId
+                  entryId:(NSString *)entryId
+          completionBlock:(BCCompletionBlock)cb
+     errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                 cbObject:(BCCallbackObject)cbObject;
 
 @end
 

--- a/Shared/BrainCloudLobby.mm
+++ b/Shared/BrainCloudLobby.mm
@@ -237,13 +237,14 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
 }
 
 //available when rtt is supported.
-//- (void)cancelFindRequest:(NSString *)lobbyId
-//          completionBlock:(BCCompletionBlock)cb
-//     errorCompletionBlock:(BCErrorCompletionBlock)ecb
-//                 cbObject:(BCCallbackObject)cbObject
-//{
-//    _client->getLobbyService()->resetFindRequest([lobbyId UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
-//}
+- (void)cancelFindRequest:(NSString *)lobbyId
+                  entryId:(NSString *)entryId
+          completionBlock:(BCCompletionBlock)cb
+     errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                 cbObject:(BCCallbackObject)cbObject
+{
+    _client->getLobbyService()->resetFindRequest([lobbyId UTF8String], [entryId UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+}
 
 @end
 

--- a/Shared/BrainCloudLobby.mm
+++ b/Shared/BrainCloudLobby.mm
@@ -243,7 +243,7 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
      errorCompletionBlock:(BCErrorCompletionBlock)ecb
                  cbObject:(BCCallbackObject)cbObject
 {
-    _client->getLobbyService()->resetFindRequest([lobbyId UTF8String], [entryId UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+    _client->getLobbyService()->cancelFindRequest([lobbyId UTF8String], [entryId UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
 }
 
 @end

--- a/Shared/BrainCloudMail.hh
+++ b/Shared/BrainCloudMail.hh
@@ -84,6 +84,26 @@
      errorCompletionBlock:(BCErrorCompletionBlock)ecb
                  cbObject:(BCCallbackObject)cbObject;
 
+/**
+ * Sends an advanced email to the email addresses.
+ *
+ * Service Name - mail
+ * Service Operation - SEND_ADVANCED_EMAIL_BY_ADDRESS
+ *
+ * @param in_emailAddresses The addresses to send the email to
+ * @param in_jsonServiceParams Parameters to send to the email service. See the documentation for
+ *	a full list. http://getbraincloud.com/apidocs/apiref/#capi-mail
+ * @param completionBlock Block to call on return of successful server response
+ * @param errorCompletionBlock Block to call on return of unsuccessful server response
+ * @param cbObject User object sent to the completion blocks
+ * @see The API documentation site for more details on cloud code
+ */
+- (void)sendAdvancedEmailByAddresses:(NSArray *)emailAddresses
+        jsonServiceParams:(NSString *)jsonServiceParams
+          completionBlock:(BCCompletionBlock)cb
+     errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                 cbObject:(BCCallbackObject)cbObject;
+
 @end
 
 #pragma clang diagnostic pop

--- a/Shared/BrainCloudMail.mm
+++ b/Shared/BrainCloudMail.mm
@@ -56,4 +56,15 @@
             [jsonServiceParams cStringUsingEncoding:NSUTF8StringEncoding], new BrainCloudCallback(cb, ecb, cbObject));
 }
 
+- (void)sendAdvancedEmailByAddresses:(NSArray *)emailAddresses
+                 jsonServiceParams:(NSString *)jsonServiceParams
+                   completionBlock:(BCCompletionBlock)cb
+              errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                          cbObject:(BCCallbackObject)cbObject
+{
+    _client->getMailService()->sendAdvancedEmailByAddresses(
+            [emailAddresses cStringUsingEncoding:NSUTF8StringEncoding],
+            [jsonServiceParams cStringUsingEncoding:NSUTF8StringEncoding], new BrainCloudCallback(cb, ecb, cbObject));
+}
+
 @end

--- a/Shared/BrainCloudMail.mm
+++ b/Shared/BrainCloudMail.mm
@@ -2,6 +2,7 @@
 #include "braincloud/BrainCloudClient.h"
 #import "BrainCloudClient.hh"
 #import "BrainCloudMail.hh"
+#include "TypeHelpers.hh"
 
 @interface BrainCloudMail ()
 {

--- a/Shared/BrainCloudMail.mm
+++ b/Shared/BrainCloudMail.mm
@@ -63,7 +63,7 @@
                           cbObject:(BCCallbackObject)cbObject
 {
     _client->getMailService()->sendAdvancedEmailByAddresses(
-            [emailAddresses cStringUsingEncoding:NSUTF8StringEncoding],
+            TypeHelpers::NSStringArrayToVector(emailAddresses),
             [jsonServiceParams cStringUsingEncoding:NSUTF8StringEncoding], new BrainCloudCallback(cb, ecb, cbObject));
 }
 

--- a/Shared/BrainCloudPlaybackStream.hh
+++ b/Shared/BrainCloudPlaybackStream.hh
@@ -158,7 +158,7 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
  * @param errorCompletionBlock Block to call on return of unsuccessful server response
  * @param cbObject User object sent to the completion blocks
  */
-- (void)protectStreamUntil:(BSString *)playbackStreamId
+- (void)protectStreamUntil:(NSString *)playbackStreamId
                    numDays:(int)numDays
            completionBlock:(BCCompletionBlock)cb
       errorCompletionBlock:(BCErrorCompletionBlock)ecb

--- a/Shared/BrainCloudPlaybackStream.hh
+++ b/Shared/BrainCloudPlaybackStream.hh
@@ -144,6 +144,26 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
                    errorCompletionBlock:(BCErrorCompletionBlock)ecb
                                cbObject:(BCCallbackObject)cbObject;
 
+/**
+ * Protects a playback stream from being purged (but not deleted) for the given number of days (from now).
+ * If the number of days given is less than the normal purge interval days (from createdAt), the longer protection date is applied.
+ * Can only be called by users involved in the playback stream.
+ * 
+ * Service Name - Playback Stream
+ * Service Operation - PROTECT_STREAM_UNTIL
+ * 
+ * @param playbackStreamId Identifies the stream to protect
+ * @param numDays The number of days the stream is to be protected (from now)
+ * @param completionBlock Block to call on return of successful server response
+ * @param errorCompletionBlock Block to call on return of unsuccessful server response
+ * @param cbObject User object sent to the completion blocks
+ */
+- (void)protectStreamUntil:(BSString *)playbackStreamId
+                   numDays:(int)numDays
+           completionBlock:(BCCompletionBlock)cb
+      errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                  cbObject:(BCCallbackObject)cbObject;
+
 @end
 
 #pragma clang diagnostic pop

--- a/Shared/BrainCloudPlaybackStream.mm
+++ b/Shared/BrainCloudPlaybackStream.mm
@@ -103,4 +103,12 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
 
 }
 
+- (void)protectStreamUntil:(NSString *)playbackStreamId
+                   numDays:(int)numDays
+           completionBlock:(BCCompletionBlock)cb
+      errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                  cbObject:(BCCallbackObject)cbObject
+{
+    _client->getPlaybackStreamService()->protectStreamUntil([playbackStreamId UTF8String], numDays, new BrainCloudCallback(cb, ecb, cbObject));
+}
 @end

--- a/Tests/TestAuthentication.m
+++ b/Tests/TestAuthentication.m
@@ -278,4 +278,12 @@
     [self waitForResult];
 }
 
+- (void)testGetServerVersion
+{
+    [[m_client authenticationService] getServerVersion:successBlock
+                                  errorCompletionBlock:failureBlock
+                                              cbObject:nil];
+    [self waitForResult];
+}
+
 @end

--- a/Tests/TestEvent.m
+++ b/Tests/TestEvent.m
@@ -40,12 +40,12 @@ NSString *eventData = @"{ \"globalTestName\":\"testValue\" }";
 {
     NSArray *toIds = @[[TestFixtureBase getUser:@"UserA"].m_profileId];
     [m_client registerEventCallback:eventBlock];
-    [[m_client eventService] testSendEventToProfiles:toIds
-                                           eventType:eventType
-                                           eventData:eventData
-                                     completionBlock:successBlock
-                                errorCompletionBlock:failureBlock
-                                            cbObject:nil];
+    [[m_client eventService] SendEventToProfiles:toIds
+                                       eventType:eventType
+                                       eventData:eventData
+                                 completionBlock:successBlock
+                            errorCompletionBlock:failureBlock
+                                        cbObject:nil];
     [self waitForResult];
     [m_client deregisterEventCallback];
 }

--- a/Tests/TestEvent.m
+++ b/Tests/TestEvent.m
@@ -40,7 +40,7 @@ NSString *eventData = @"{ \"globalTestName\":\"testValue\" }";
 {
     NSArray *toIds = @[[TestFixtureBase getUser:@"UserA"].m_profileId];
     [m_client registerEventCallback:eventBlock];
-    [[m_client eventService] SendEventToProfiles:toIds
+    [[m_client eventService] sendEventToProfiles:toIds
                                        eventType:eventType
                                        eventData:eventData
                                  completionBlock:successBlock

--- a/Tests/TestEvent.m
+++ b/Tests/TestEvent.m
@@ -36,6 +36,20 @@ NSString *eventData = @"{ \"globalTestName\":\"testValue\" }";
     }
 }
 
+-(void)testSendEventToProfiles
+{
+    NSArray *toIds = @[[TestFixtureBase getUser:@"UserA"].m_profileId];
+    [m_client registerEventCallback:eventBlock];
+    [[m_client eventService] testSendEventToProfiles:toIds
+                                           eventType:eventType
+                                           eventData:eventData
+                                     completionBlock:successBlock
+                                errorCompletionBlock:failureBlock
+                                            cbObject:nil];
+    [self waitForResult];
+    [m_client deregisterEventCallback];
+}
+
 - (void)testUpdateIncomingEventData
 {
     NSString* eventId = [self sendEvent];

--- a/Tests/TestFriend.m
+++ b/Tests/TestFriend.m
@@ -50,6 +50,16 @@
     [self waitForFailedResult];
 }
 
+- (void)testGetProfileInfoForExternalAuthIdIfExists
+{
+    [[m_client friendService] getProfileInfoForExternalAuthIdIfExists:[TestFixtureBase getUser:@"UserA"].m_profileId
+                                       externalAuthType:@"failAuth"
+                                          completionBlock:successBlock
+                                     errorCompletionBlock:failureBlock
+                                                 cbObject:nil];
+    [self waitForFailedResult];
+}
+
 - (void)testFindUsersByExactName
 {
     [[m_client friendService] findUsersByExactName:@"name"

--- a/Tests/TestFriend.m
+++ b/Tests/TestFriend.m
@@ -53,11 +53,11 @@
 - (void)testGetProfileInfoForExternalAuthIdIfExists
 {
     [[m_client friendService] getProfileInfoForExternalAuthIdIfExists:[TestFixtureBase getUser:@"UserA"].m_profileId
-                                       externalAuthType:@"failAuth"
+                                       externalAuthType:@"testExternal"
                                           completionBlock:successBlock
                                      errorCompletionBlock:failureBlock
                                                  cbObject:nil];
-    [self waitForFailedResult];
+    [self waitForResult];
 }
 
 - (void)testFindUsersByExactName

--- a/Tests/TestFriend.m
+++ b/Tests/TestFriend.m
@@ -30,6 +30,16 @@
     [self waitForResult];
 }
 
+- (void)testGetProfileInfoForCredentialIfExists
+{
+    [[m_client friendService] getProfileInfoForCredentialIfExists:[TestFixtureBase getUser:@"UserA"].m_id
+                                       authenticationType:[AuthenticationTypeObjc Universal]
+                                         completionBlock:successBlock
+                                    errorCompletionBlock:failureBlock
+                                                cbObject:nil];
+    [self waitForResult];
+}
+
 - (void)testGetProfileInfoForExternalAuthId
 {
     [[m_client friendService] getProfileInfoForExternalAuthId:[TestFixtureBase getUser:@"UserA"].m_profileId

--- a/Tests/TestGroup.m
+++ b/Tests/TestGroup.m
@@ -656,7 +656,7 @@ NSString *groupId = @"";
                             completionBlock:successBlock
                        errorCompletionBlock:failureBlock
                                    cbObject:nil];
-    [self waitForResult]
+    [self waitForResult];
 
     [self deleteGroup];
     [self logout];

--- a/Tests/TestGroup.m
+++ b/Tests/TestGroup.m
@@ -565,6 +565,25 @@ NSString *groupId = @"";
     [self deleteGroup];
 }
 
+-(void)testUpdateGroupEntityAcl
+{
+    [self authenticate:@"UserA"];
+    [self createGroup];
+
+    NSString *entityId = [self createGroupEntity];
+
+    [[m_client groupService] updateGroupEntityAcl:groupId
+                                         entityId:entityId
+                                             acl:testAcl
+                                 completionBlock:successBlock
+                            errorCompletionBlock:failureBlock
+                                        cbObject:nil];
+    [self waitForResult]
+
+    [self deleteGroup];
+    [self logout];
+}
+
 - (void)testUpdateGroupEntityData
 {
     [self authenticate:@"UserA"];
@@ -625,6 +644,22 @@ NSString *groupId = @"";
                                  cbObject:nil];
     //no group exists
     [self waitForFailedResult];
+}
+
+-(void)testUpdateGroupAcl
+{
+    [self authenticate:@"UserA"];
+    [self createGroup];
+
+    [[m_client groupService] updateGroupAcl:groupId
+                                        acl:testAcl
+                            completionBlock:successBlock
+                       errorCompletionBlock:failureBlock
+                                   cbObject:nil];
+    [self waitForResult]
+
+    [self deleteGroup];
+    [self logout];
 }
 
 - (void)testPost

--- a/Tests/TestGroup.m
+++ b/Tests/TestGroup.m
@@ -188,7 +188,7 @@ NSString *groupId = @"";
     [self authenticate:@"UserA"];
     [self createGroup];
 
-    NSString *entityId = [self createGroupEntity];
+    NSString *entityId = [self createGroupEntity:false];
 
     [[m_client groupService] deleteGroupEntity:groupId
                                       entityId:entityId
@@ -275,7 +275,7 @@ NSString *groupId = @"";
     [self authenticate:@"UserA"];
     [self createGroup];
 
-    NSString *entityId = [self createGroupEntity];
+    NSString *entityId = [self createGroupEntity:false];
 
     [[m_client groupService] incrementGroupEntityData:groupId
                                              entityId:entityId
@@ -440,7 +440,7 @@ NSString *groupId = @"";
     [self authenticate:@"UserA"];
     [self createGroup];
 
-    NSString *entityId = [self createGroupEntity];
+    NSString *entityId = [self createGroupEntity:false];
 
     [[m_client groupService] readGroupEntity:groupId
                                     entityId:entityId
@@ -570,7 +570,7 @@ NSString *groupId = @"";
     [self authenticate:@"UserA"];
     [self createGroup];
 
-    NSString *entityId = [self createGroupEntity];
+    NSString *entityId = [self createGroupEntity:true];
 
     [[m_client groupService] updateGroupEntityAcl:groupId
                                          entityId:entityId
@@ -589,7 +589,7 @@ NSString *groupId = @"";
     [self authenticate:@"UserA"];
     [self createGroup];
 
-    NSString *entityId = [self createGroupEntity];
+    NSString *entityId = [self createGroupEntity:false];
 
     [[m_client groupService] updateGroupEntityData:groupId
                                           entityId:entityId
@@ -778,11 +778,11 @@ NSString *groupId = @"";
     groupId = [(NSDictionary *)[jsonObj objectForKey:@"data"] objectForKey:@"groupId"];
 }
 
-- (NSString *)createGroupEntity
+- (NSString *)createGroupEntity:(BOOL)isOwnedByGroupMember
 {
     [[m_client groupService] createGroupEntity:groupId
                                     entityType:groupEntityType
-                          isOwnedByGroupMember:NO
+                          isOwnedByGroupMember:isOwnedByGroupMember
                                            acl:testAcl
                                       jsonData:testJsonPair
                                completionBlock:successBlock

--- a/Tests/TestGroup.m
+++ b/Tests/TestGroup.m
@@ -578,7 +578,7 @@ NSString *groupId = @"";
                                  completionBlock:successBlock
                             errorCompletionBlock:failureBlock
                                         cbObject:nil];
-    [self waitForResult]
+    [self waitForResult];
 
     [self deleteGroup];
     [self logout];

--- a/Tests/TestIdentity.m
+++ b/Tests/TestIdentity.m
@@ -96,6 +96,19 @@
     [self waitForResult];
 }
 
+- (void)testGetIdentityStatus
+{
+    NSString *externalAuthName = @"";
+
+    [[_bc identityService] getIdentityStatus:
+            authenticationType:[AuthenticationTypeObjc Universal]
+              externalAuthName:externalAuthName
+               completionBlock:successBlock
+          errorCompletionBlock:failureBlock
+                      cbObject:nil];
+    [self waitForResult];
+}
+
 - (void)testGetExpiredIdentities
 {
     [[m_client identityService] getExpiredIdentities:successBlock errorCompletionBlock:failureBlock cbObject:nil];

--- a/Tests/TestIdentity.m
+++ b/Tests/TestIdentity.m
@@ -100,12 +100,11 @@
 {
     NSString *externalAuthName = @"";
 
-    [[m_client identityService] getIdentityStatus:
-            authenticationType:[AuthenticationTypeObjc Universal]
-              externalAuthName:externalAuthName
-               completionBlock:successBlock
-          errorCompletionBlock:failureBlock
-                      cbObject:nil];
+    [[m_client identityService] getIdentityStatus:[AuthenticationTypeObjc Universal]
+                                 externalAuthName:externalAuthName
+                                  completionBlock:successBlock
+                             errorCompletionBlock:failureBlock
+                                         cbObject:nil];
     [self waitForResult];
 }
 

--- a/Tests/TestIdentity.m
+++ b/Tests/TestIdentity.m
@@ -100,7 +100,7 @@
 {
     NSString *externalAuthName = @"";
 
-    [[_bc identityService] getIdentityStatus:
+    [[m_client identityService] getIdentityStatus:
             authenticationType:[AuthenticationTypeObjc Universal]
               externalAuthName:externalAuthName
                completionBlock:successBlock

--- a/Tests/TestLeaderboard.m
+++ b/Tests/TestLeaderboard.m
@@ -451,7 +451,7 @@ NSString *eventId = @"tournamentRewardTest";
                                                                          groupId:groupId
                                                                            score:99
                                                                        scoreData:@""
-                                                           configJson:configJson:@"{\"leaderboardType\": \"HIGH_VALUE\", \"rotationType\": \"NEVER\", \"numDaysToRotate\": null, \"resetAt\": null, \"retainedCount\": 2, \"expireInMins\": None}"
+                                                                      configJson:@"{\"leaderboardType\": \"HIGH_VALUE\", \"rotationType\": \"NEVER\", \"numDaysToRotate\": null, \"resetAt\": null, \"retainedCount\": 2, \"expireInMins\": None}"
                                                                  completionBlock:successBlock
                                                             errorCompletionBlock:failureBlock
                                                                         cbObject:nil];

--- a/Tests/TestLeaderboard.m
+++ b/Tests/TestLeaderboard.m
@@ -427,6 +427,44 @@ NSString *eventId = @"tournamentRewardTest";
     [self waitForResult];
 }
 
+- (void)testPostScoreToDynamicGroupLeaderboardUsingConfig
+{
+    [[m_client groupService] createGroup:@"testGroup"
+                               groupType:@"test"
+                             isOpenGroup:NO
+                                     acl:@""
+                                jsonData:@""
+                     jsonOwnerAttributes:@""
+             jsonDefaultMemberAttributes:@""
+                         completionBlock:successBlock
+                    errorCompletionBlock:failureBlock
+                                cbObject:nil];
+    [self waitForResult];
+    
+    NSData *data = [self.jsonResponse dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *jsonObj =
+        [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
+
+    NSString *groupId = [(NSDictionary *)[jsonObj objectForKey:@"data"] objectForKey:@"groupId"];
+
+    [[m_client leaderboardService] postScoreToDynamicGroupLeaderboardUsingConfig:groupLeaderboardId
+                                                                         groupId:groupId
+                                                                           score:99
+                                                                       scoreData:@""
+                                                           configJson:configJson:@"{\"leaderboardType\": \"HIGH_VALUE\", \"rotationType\": \"NEVER\", \"numDaysToRotate\": null, \"resetAt\": null, \"retainedCount\": 2, \"expireInMins\": None}"
+                                                                 completionBlock:successBlock
+                                                            errorCompletionBlock:failureBlock
+                                                                        cbObject:nil];
+    [self waitForResult];
+
+    [[m_client groupService] deleteGroup:groupId
+                                 version:-1
+                         completionBlock:successBlock
+                    errorCompletionBlock:failureBlock
+                                cbObject:nil];
+    [self waitForResult];
+}
+
 - (void)testGetGroupSocialLeaderboard
 {
     [[m_client groupService] createGroup:@"testGroup"

--- a/Tests/TestLobby.m
+++ b/Tests/TestLobby.m
@@ -118,6 +118,51 @@
     [self waitForResult];
 }
 
+- (void)testCancelFindRequest
+{
+    authenticateUniversal:[TestFixtureBase getUser:@"UserA"].m_id
+     password:[TestFixtureBase getUser:@"UserA"].m_password
+     forceCreate:true
+     completionBlock:successBlock
+     errorCompletionBlock:failureBlock
+     cbObject:nil];
+    [self waitForResult];
+    
+    NSString* _lobbyType = @"MATCH_UNRANKED";
+    NSArray* _otherUserCxIds = @[];
+    NSString* _extraJson = @"{}";
+    NSString* _settings = @"{}";
+    NSString* _teamCode = @"all";
+    NSString* _algo = @"{\"strategy\":\"ranged-absolute\",\"alignment\":\"center\",\"ranges\":[1000]}";
+    NSString* _filterJson = @"{}";
+    
+    [[m_client lobbyService] findOrCreateLobby:_lobbyType
+                                        rating:0
+                                      maxSteps:1
+                                          algo:_algo
+                                    filterJson:_filterJson
+                                otherUserCxIds:_otherUserCxIds
+                                       isReady:true
+                                     extraJson:_extraJson
+                                      teamCode:_teamCode
+                                      settings:_settings
+                               completionBlock:successBlock
+                          errorCompletionBlock:failureBlock
+                                      cbObject:nil];
+    [self waitForResult];
+
+    NSData *data = [self.jsonResponse dataUsingEncoding:NSUTF8StringEncoding];
+    NSDictionary *jsonObj = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
+    NSString *_entryId = [(NSDictionary *)[jsonObj objectForKey:@"data"] objectForKey:@"entryId"];
+
+    [[m_client lobbyService] testCancelFindRequest:_lobbyType
+                                           entryId: _entryId
+                                   completionBlock:successBlock
+                              errorCompletionBlock:failureBlock
+                                          cbObject:nil];
+    [self waitForResult];
+}
+
 - (void)testGetLobbyData
 {
     [[m_client authenticationService]

--- a/Tests/TestLobby.m
+++ b/Tests/TestLobby.m
@@ -120,6 +120,7 @@
 
 - (void)testCancelFindRequest
 {
+    [[m_client authenticationService]
     authenticateUniversal:[TestFixtureBase getUser:@"UserA"].m_id
      password:[TestFixtureBase getUser:@"UserA"].m_password
      forceCreate:true

--- a/Tests/TestLobby.m
+++ b/Tests/TestLobby.m
@@ -156,11 +156,11 @@
     NSDictionary *jsonObj = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
     NSString *_entryId = [(NSDictionary *)[jsonObj objectForKey:@"data"] objectForKey:@"entryId"];
 
-    [[m_client lobbyService] testCancelFindRequest:_lobbyType
-                                           entryId: _entryId
-                                   completionBlock:successBlock
-                              errorCompletionBlock:failureBlock
-                                          cbObject:nil];
+    [[m_client lobbyService] cancelFindRequest:_lobbyType
+                                       entryId:_entryId
+                               completionBlock:successBlock
+                          errorCompletionBlock:failureBlock
+                                      cbObject:nil];
     [self waitForResult];
 }
 

--- a/Tests/TestMail.m
+++ b/Tests/TestMail.m
@@ -64,4 +64,23 @@
     [self waitForResult];
 }
 
+- (void)testSendAdvancedEmailByAddresses
+{
+    NSMutableDictionary* dict = [[NSMutableDictionary alloc] init];
+    [dict setObject:@"Test Subject - TestSendAdvancedEmailByAddress" forKey:@"subject"];
+    [dict setObject:@"Test body" forKey:@"body"];
+    [dict setObject:[NSArray arrayWithObjects:@"unit-test", nil] forKey:@"categories"];
+
+    NSString * jsonData = [TestFixtureBase getJsonString:dict];
+
+    NSArray *emailAddresses = @["testEmail@email.com", "anotherTestEmail@email.com"];
+
+    [[m_client mailService] sendAdvancedEmailByAddresses:emailAddresses
+                                     jsonServiceParams:jsonData
+                                       completionBlock:successBlock
+                                  errorCompletionBlock:failureBlock
+                                              cbObject:nil];
+    [self waitForResult];
+}
+
 @end

--- a/Tests/TestMail.m
+++ b/Tests/TestMail.m
@@ -73,7 +73,7 @@
 
     NSString * jsonData = [TestFixtureBase getJsonString:dict];
 
-    NSArray *emailAddresses = @["testEmail@email.com", "anotherTestEmail@email.com"];
+    NSArray *emailAddresses = @[@"testEmail@email.com", @"anotherTestEmail@email.com"];
 
     [[m_client mailService] sendAdvancedEmailByAddresses:emailAddresses
                                      jsonServiceParams:jsonData

--- a/Tests/TestPlaybackStream.m
+++ b/Tests/TestPlaybackStream.m
@@ -75,6 +75,20 @@
     [self waitForResult];
 }
 
+-(void)testProtectStreamUntil
+{
+    NSString *playbackStreamId = [self startStream];
+    (int32_t) numDays = 1;
+
+    [[m_client playbackStreamService] protectStreamUntil:playbackStreamId
+                                                 numDays:numDays
+                                         completionBlock:successBlock
+                                    errorCompletionBlock:failureBlock
+                                                cbObject:nil];
+    [self waitForResult]
+    [self endStream:playbackStreamId];
+}
+
 - (void)testReadStream
 {
     NSString *streamId = [self startStream];

--- a/Tests/TestPlaybackStream.m
+++ b/Tests/TestPlaybackStream.m
@@ -78,14 +78,13 @@
 -(void)testProtectStreamUntil
 {
     NSString *playbackStreamId = [self startStream];
-    (int32_t) numDays = 1;
 
     [[m_client playbackStreamService] protectStreamUntil:playbackStreamId
-                                                 numDays:numDays
+                                                 numDays:1
                                          completionBlock:successBlock
                                     errorCompletionBlock:failureBlock
                                                 cbObject:nil];
-    [self waitForResult]
+    [self waitForResult];
     [self endStream:playbackStreamId];
 }
 


### PR DESCRIPTION
New APIs:
- GET_IDENTITY_STATUS
- GET_PROFILE_INFO_FOR_CREDENTIAL_IF_EXISTS
- GET_PROFILE_INFO_FOR_EXTERNAL_AUTH_ID_IF_EXISTS
- GET_SERVER_VERSION
- POST_GROUP_SCORE_DYNAMIC_USING_CONFIG
- PROTECT_STREAM_UNTIL
- SEND_ADVANCED_EMAIL_BY_ADDRESSES
- SEND_EVENT_TO_PROFILES
- UPDATE_GROUP_ACL
- UPDATE_GROUP_ENTITY_ACL

Green Test: https://vmjenkins.bitheads.com/view/Dev_ObjC/job/bitHeads_BrainCloud_Client_UnitTest_ObjC_develop_internal/1858/