### PR TITLE
[BCLOUD-11096] Remove Deprecated API

### DIFF
--- a/Shared/BrainCloudAppStore.hh
+++ b/Shared/BrainCloudAppStore.hh
@@ -38,12 +38,12 @@
  * @param errorCompletionBlock Block to call on return of unsuccessful server response
  * @param cbObject User object sent to the completion blocks
  */
--(void)cachePurchaseContext:(NSString *)storeId
-                      iapId:(NSString *)iapId
-                    payload:(NSString *)payload
-            completionBlock:(BCCompletionBlock)cb
-       errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                   cbObject:(BCCallbackObject)cbObject;
+-(void)cachePurchasePayloadContext:(NSString *)storeId
+                             iapId:(NSString *)iapId
+                           payload:(NSString *)payload
+                   completionBlock:(BCCompletionBlock)cb
+              errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                          cbObject:(BCCallbackObject)cbObject;
 
 /**
  * Verifies that purchase was properly made at the store

--- a/Shared/BrainCloudAppStore.mm
+++ b/Shared/BrainCloudAppStore.mm
@@ -50,14 +50,14 @@
  * @param errorCompletionBlock Block to call on return of unsuccessful server response
  * @param cbObject User object sent to the completion blocks
  */
--(void)cachePurchaseContext:(NSString *)storeId
-                      iapId:(NSString *)iapId
-                    payload:(NSString *)payload
-            completionBlock:(BCCompletionBlock)cb
-       errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                   cbObject:(BCCallbackObject)cbObject
+-(void)cachePurchasePayloadContext:(NSString *)storeId
+                             iapId:(NSString *)iapId
+                           payload:(NSString *)payload
+                   completionBlock:(BCCompletionBlock)cb
+              errorCompletionBlock:(BCErrorCompletionBlock)ecb
+                          cbObject:(BCCallbackObject)cbObject
 {
-    _client->getAppStoreService()->cachePurchaseContext([storeId UTF8String], [iapId UTF8String], [payload UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
+    _client->getAppStoreService()->cachePurchasePayloadContext([storeId UTF8String], [iapId UTF8String], [payload UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
 }
 
 /**

--- a/Shared/BrainCloudClient.hh
+++ b/Shared/BrainCloudClient.hh
@@ -79,37 +79,6 @@ typedef NS_ENUM(NSUInteger, BCBrainCloudUpdateType)
 @interface BrainCloudClient : NSObject
 
 /**
- * BrainCloudClient is a singleton object. This method gives the caller access
- * to the singleton object in order to use the class.
- *
- * @return BrainCloudClient * - pointer to the singleton BrainCloudClient object
- *
- * @deprecated Use of the *singleton* has been deprecated. We recommend that you create your own *variable* to hold an instance of the brainCloudWrapper. Explanation here: http://getbraincloud.com/apidocs/wrappers-clients-and-inconvenient-singletons/
- */
-+ (BrainCloudClient *)getInstance;
-
-/**
- * Internal method used by the brainCloud client to set the instance.
- *
- * @param BrainCloudClient * - pointer to the singleton BrainCloudClient object
- *
- * @deprecated Use of the *singleton* has been deprecated. We recommend that you create your own *variable* to hold an instance of the brainCloudWrapper. Explanation here: http://getbraincloud.com/apidocs/wrappers-clients-and-inconvenient-singletons/
- */
-+ (void)setInstance: (BrainCloudClient *) instance;
-
-/**
- * Disabling Singleton mode will ensure an error is thrown if the brainCloud Singleton is used
- *
- * @param state of singleton mode
- */
-+ (void) setEnableSingletonMode: (bool) state;
-
-/**
- * @return state of singleton mode
- */
-+ (bool) getEnableSingletonMode;
-
-/**
  * Initializes the brainCloud Client
  */
 - (instancetype) init;

--- a/Shared/BrainCloudClient.mm
+++ b/Shared/BrainCloudClient.mm
@@ -169,35 +169,7 @@ class ObjCNetworkErrorCallback : public BrainCloud::INetworkErrorCallback
 
 @implementation BrainCloudClient
 
-static BrainCloudClient *s_instance = nil;
 const NSString* BC_SERVER_URL = @"https://api.braincloudservers.com/dispatcherv2";
-
-+ (BrainCloudClient *)getInstance
-{
-    NSAssert(BrainCloud::BrainCloudClient::EnableSingletonMode, [NSString stringWithUTF8String:BrainCloud::BrainCloudClient::SingletonUseErrorMessage]);
-    
-    @synchronized(self) {
-        if(s_instance == nil) {
-            s_instance = [[BrainCloudClient alloc] init];
-        }
-    }
-    return s_instance;
-}
-
-+ (void)setInstance: (BrainCloudClient *) instance
-{
-    s_instance = instance;
-}
-
-+ (void) setEnableSingletonMode: (bool) state
-{
-    BrainCloud::BrainCloudClient::EnableSingletonMode = state;
-}
-
-+ (bool) getEnableSingletonMode
-{
-    return BrainCloud::BrainCloudClient::EnableSingletonMode;
-}
 
 - (instancetype)init
 {

--- a/Shared/BrainCloudClient.mm
+++ b/Shared/BrainCloudClient.mm
@@ -698,6 +698,4 @@ const NSString* BC_SERVER_URL = @"https://api.braincloudservers.com/dispatcherv2
     return _groupFileService;
 }
 
-+ (BrainCloudClient *)defaultClient { return [BrainCloudClient getInstance]; }
-
 @end

--- a/Shared/BrainCloudLeaderboard.hh
+++ b/Shared/BrainCloudLeaderboard.hh
@@ -522,38 +522,6 @@ typedef NS_ENUM(NSUInteger, SortOrder) { HIGH_TO_LOW, LOW_TO_HIGH };
                       cbObject:(BCCallbackObject)cbObject;
 
 /**
-* Post the players score to the given social leaderboard.
-* Pass leaderboard config data to dynamically create if necessary.
-* You can optionally send a user-defined json string of data
-* with the posted score. This string could include information
-* relevant to the posted score.
-*
-* Service Name - SocialLeaderboard
-* Service Operation - PostScoreDynamic
-*
-* @param leaderboardId The leaderboard to post to
-* @param score The score to post
-* @param data Optional user-defined data to post with the score
-* @param leaderboardType leaderboard type
-* @param rotationType Type of rotation
-* @param rotationReset Date to start rotation calculations
-* @param retainedCount How many rotations to keep
-* @param completionBlock Block to call on return of successful server response
-* @param errorCompletionBlock Block to call on return of unsuccessful server response
-* @param cbObject User object sent to the completion blocks
-*/
-- (void)postScoreToDynamicLeaderboard:(NSString *)leaderboardId
-                                score:(int)score
-                             jsonData:(NSString *)jsonData
-                      leaderboardType:(LeaderboardType)leaderboardType
-                         rotationType:(RotationType)rotationType
-                       roatationReset:(NSDate *)rotationReset
-                        retainedCount:(int)retainedCount
-                      completionBlock:(BCCompletionBlock)cb
-                 errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                             cbObject:(BCCallbackObject)cbObject;
-
-/**
  * Post the player's score to the given social leaderboard, 
  * dynamically creating the leaderboard if it does not exist yet. 
  * To create new leaderboard, configJson must specify
@@ -629,37 +597,6 @@ typedef NS_ENUM(NSUInteger, SortOrder) { HIGH_TO_LOW, LOW_TO_HIGH };
                       completionBlock:(BCCompletionBlock)cb
                  errorCompletionBlock:(BCErrorCompletionBlock)ecb
                              cbObject:(BCCallbackObject)cbObject;
-/**
-* Post the players score to the given social leaderboard.
-* Pass leaderboard config data to dynamically create if necessary.
-* You can optionally send a user-defined json string of data
-* with the posted score. This string could include information
-* relevant to the posted score.
-*
-* Service Name - SocialLeaderboard
-* Service Operation - PostScoreDynamic
-*
-* @param leaderboardId The leaderboard to post to
-* @param score The score to post
-* @param data Optional user-defined data to post with the score
-* @param leaderboardType leaderboard type
-* @param rotationReset Date to start rotation calculations
-* @param retainedCount How many rotations to keep
-* @param numDaysToRotate How many days between each rotation
-* @param completionBlock Block to call on return of successful server response
-* @param errorCompletionBlock Block to call on return of unsuccessful server response
-* @param cbObject User object sent to the completion blocks
-*/
-- (void)postScoreToDynamicLeaderboardDays:(NSString *)leaderboardId
-                                    score:(int)score
-                                 jsonData:(NSString *)jsonData
-                          leaderboardType:(LeaderboardType)leaderboardType
-                           roatationReset:(NSDate *)rotationReset
-                            retainedCount:(int)retainedCount
-                          numDaysToRotate:(int)numDaysToRotate
-                          completionBlock:(BCCompletionBlock)cb
-                     errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                                 cbObject:(BCCallbackObject)cbObject;
 
 /**
 * Post the players score to the given social leaderboard.
@@ -944,34 +881,6 @@ typedef NS_ENUM(NSUInteger, SortOrder) { HIGH_TO_LOW, LOW_TO_HIGH };
                     completionBlock:(BCCompletionBlock)cb
                errorCompletionBlock:(BCErrorCompletionBlock)ecb
                            cbObject:(BCCallbackObject)cbObject;
-
-/**
- * Post score to Group Leaderboard - Note the user must be a member of the group
- *
- * Service Name - leaderboard
- * Service Operation - POST_GROUP_SCORE
- *
- * @param leaderboardId
- * @param groupId
- * @param score
- * @param jsonData custom data
- * @param leaderboardType
- * @param rotationType
- * @param rotationResetTime
- * @param retainedCount
- * @param callback The method to be invoked when the server response is received
- */
-- (void)postScoreToDynamicGroupLeaderboard:(NSString *)leaderboardId
-                                   groupId:(NSString *)groupId
-                                     score:(int)score
-                                  jsonData:(NSString *)jsonData
-                           leaderboardType:(NSString *)leaderboardType
-                              rotationType:(NSString *)rotationType
-                         rotationResetTime:(int64_t)rotationResetTime
-                             retainedCount:(int32_t)retainedCount
-                           completionBlock:(BCCompletionBlock)cb
-                      errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                                  cbObject:(BCCallbackObject)cbObject;
 
 /**
  * Post score to Group Leaderboard - Note the user must be a member of the group - uses UTC time

--- a/Shared/BrainCloudLeaderboard.mm
+++ b/Shared/BrainCloudLeaderboard.mm
@@ -240,29 +240,6 @@
         [leaderboardId UTF8String], score, [jsonOtherData UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
 }
 
-// this has been deprecated in C++ but the obj-c wrapper is still available
-//Use postScoreToDynamicLeaderboardUTC instead - Removal after september 1 2021
-- (void)postScoreToDynamicLeaderboard:(NSString *)leaderboardId
-                                score:(int)score
-                             jsonData:(NSString *)jsonData
-                      leaderboardType:(LeaderboardType)leaderboardType
-                         rotationType:(RotationType)rotationType
-                       roatationReset:(NSDate *)rotationReset
-                        retainedCount:(int)retainedCount
-                      completionBlock:(BCCompletionBlock)cb
-                 errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                             cbObject:(BCCallbackObject)cbObject
-{
-    time_t time = [rotationReset timeIntervalSince1970];
-    struct tm *timeStruct = localtime(&time);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-    _client->getLeaderboardService()->postScoreToDynamicLeaderboard(
-        [leaderboardId UTF8String], score, [jsonData UTF8String], (BrainCloud::SocialLeaderboardType)leaderboardType,
-        (BrainCloud::RotationType)rotationType, timeStruct, retainedCount, new BrainCloudCallback(cb, ecb, cbObject));
-#pragma clang diagnostic pop
-}
-
 - (void)postScoreToDynamicLeaderboardUsingConfig:(NSString *)leaderboardId
                                            score:(int)score
                                        scoreData:(NSString *)scoreData
@@ -289,29 +266,6 @@
     _client->getLeaderboardService()->postScoreToDynamicLeaderboardUTC(
         [leaderboardId UTF8String], score, [jsonData UTF8String], (BrainCloud::SocialLeaderboardType)leaderboardType,
         (BrainCloud::RotationType)rotationType, rotationResetUTC, retainedCount, new BrainCloudCallback(cb, ecb, cbObject));
-}
-
-// this has been deprecated in C++ but the obj-c wrapper is still available
-// Use postScoreToDynamicLeaderboardDaysUTC instead - Removal after september 1 2021
-- (void)postScoreToDynamicLeaderboardDays:(NSString *)leaderboardId
-                                    score:(int)score
-                                 jsonData:(NSString *)jsonData
-                          leaderboardType:(LeaderboardType)leaderboardType
-                           roatationReset:(NSDate *)rotationReset
-                            retainedCount:(int)retainedCount
-                          numDaysToRotate:(int)numDaysToRotate
-                          completionBlock:(BCCompletionBlock)cb
-                     errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                                 cbObject:(BCCallbackObject)cbObject
-{
-    time_t time = [rotationReset timeIntervalSince1970];
-    struct tm *timeStruct = localtime(&time);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-    _client->getLeaderboardService()->postScoreToDynamicLeaderboardDays(
-        [leaderboardId UTF8String], score, [jsonData UTF8String], (BrainCloud::SocialLeaderboardType)leaderboardType,
-        timeStruct, retainedCount, numDaysToRotate, new BrainCloudCallback(cb, ecb, cbObject));
-#pragma clang diagnostic pop
 }
 
 - (void)postScoreToDynamicLeaderboardDaysUTC:(NSString *)leaderboardId
@@ -504,28 +458,6 @@
 {
     _client->getLeaderboardService()->postScoreToGroupLeaderboard(
         [leaderboardId UTF8String], [groupId UTF8String], score, [jsonData UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
-}
-
-// this has been deprecated in C++ but the obj-c wrapper is still available
-// Use postScoreToDynamicGroupLeaderboardUTC instead - Removal after september 1 2021
-- (void)postScoreToDynamicGroupLeaderboard:(NSString *)leaderboardId
-                                   groupId:(NSString *)groupId
-                                     score:(int)score
-                                  jsonData:(NSString *)jsonData
-                           leaderboardType:(NSString *)leaderboardType
-                              rotationType:(NSString *)rotationType
-                         rotationResetTime:(int64_t)rotationResetTime
-                             retainedCount:(int32_t)retainedCount
-                           completionBlock:(BCCompletionBlock)cb
-                      errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                                  cbObject:(BCCallbackObject)cbObject
-{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-    _client->getLeaderboardService()->postScoreToDynamicGroupLeaderboard(
-                                                                         [leaderboardId UTF8String], [groupId UTF8String], score, [jsonData UTF8String],[leaderboardType UTF8String],
-                                                                         [rotationType UTF8String], rotationResetTime, retainedCount, new BrainCloudCallback(cb, ecb, cbObject));
-#pragma clang diagnostic pop
 }
 
 - (void)postScoreToDynamicGroupLeaderboardUTC:(NSString *)leaderboardId

--- a/Shared/BrainCloudPlayerState.hh
+++ b/Shared/BrainCloudPlayerState.hh
@@ -106,14 +106,6 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
               cbObject:(BCCallbackObject)cbObject;
 
 /**
- * @deprecated user updateUserName instead - Removal September 1, 2021
-*/
-- (void)updateName:(NSString *)name
-       completionBlock:(BCCompletionBlock)completionBlock
-  errorCompletionBlock:(BCErrorCompletionBlock)ecb
-              cbObject:(BCCallbackObject)cbObject;
-
-/**
 * Retrieve the player attributes.
 *
 * Service Name - PlayerState

--- a/Shared/BrainCloudPlayerState.mm
+++ b/Shared/BrainCloudPlayerState.mm
@@ -105,15 +105,6 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
             [name UTF8String], new BrainCloudCallback(completionBlock, ecb, cbObject));
 }
 
-- (void)updateName:(NSString *)name
-       completionBlock:(BCCompletionBlock)completionBlock
-  errorCompletionBlock:(BCErrorCompletionBlock)ecb
-              cbObject:(BCCallbackObject)cbObject
-{
-    _client->getPlayerStateService()->updateUserName(
-            [name UTF8String], new BrainCloudCallback(completionBlock, ecb, cbObject));
-}
-
 - (void)getAttributes:(BCCompletionBlock)completionBlock
  errorCompletionBlock:(BCErrorCompletionBlock)ecb
              cbObject:(BCCallbackObject)cbObject

--- a/Shared/BrainCloudScript.hh
+++ b/Shared/BrainCloudScript.hh
@@ -42,27 +42,6 @@
                 cbObject:(BCCallbackObject)cbObject;
 
 /**
-* Allows cloud script executions to be scheduled
-*
-* Service Name - Script
-* Service Operation - ScheduleCloudScript
-*
-* @param scriptName The name of the script to be run
-* @param jsonScriptData Data to be sent to the script in json format
-* @param startDateInLocal The start date as a time struct in local time
-* @param completionBlock Block to call on return of successful server response
-* @param errorCompletionBlock Block to call on return of unsuccessful server response
-* @param cbObject User object sent to the completion blocks
-* @see The API documentation site for more details on cloud code
-*/
-- (void)scheduleRunScriptUTC:(NSString *)scriptName
-              jsonScriptData:(NSString *)jsonScriptData
-              startDateLocal:(NSDate *)startDateLocal
-             completionBlock:(BCCompletionBlock)cb
-        errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                    cbObject:(BCCallbackObject)cbObject;
-
-/**
  * Allows cloud script executions to be scheduled - DOES NOT convert to local time, keeps UTC time
  *
  * Service Name - Script

--- a/Shared/BrainCloudScript.mm
+++ b/Shared/BrainCloudScript.mm
@@ -35,24 +35,6 @@
         [scriptName cStringUsingEncoding:NSUTF8StringEncoding],
         [jsonScriptData cStringUsingEncoding:NSUTF8StringEncoding], new BrainCloudCallback(cb, ecb, cbObject));
 }
-/*
-    deprecated Use scheduleRunScriptMillisUTC instead - Removal after september 1 2021
- */
-- (void)scheduleRunScriptUTC:(NSString *)scriptName
-              jsonScriptData:(NSString *)jsonScriptData
-              startDateLocal:(NSDate *)startDateLocal
-             completionBlock:(BCCompletionBlock)cb
-        errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                    cbObject:(BCCallbackObject)cbObject
-{
-    time_t time = [startDateLocal timeIntervalSince1970];
-    struct tm *timeStruct = localtime(&time);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-    _client->getScriptService()->scheduleRunScriptUTC(
-        [scriptName UTF8String], [jsonScriptData UTF8String], timeStruct, new BrainCloudCallback(cb, ecb, cbObject));
-#pragma diagnostic pop
-}
 
 - (void)scheduleRunScriptMillisUTC:(NSString *)scriptName
               jsonScriptData:(NSString *)jsonScriptData

--- a/Shared/BrainCloudTournament.hh
+++ b/Shared/BrainCloudTournament.hh
@@ -164,28 +164,6 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
                 cbObject:(BCCallbackObject)cbObject;
 
 /**
- * Post the users score to the leaderboard - LOCAL time
- *
- * Service Name - tournament
- * Service Operation - POST_TOURNAMENT_SCORE
- *
- * @param leaderboardId The leaderboard for the tournament
- * @param score The score to post
- * @param jsonData Optional data attached to the leaderboard entry
- * @param roundStartedTimeLocal Time the user started the match and is converted
- * @param completionBlock Block to call on return of successful server response
- * @param errorCompletionBlock Block to call on return of unsuccessful server response
- * @param cbObject User object sent to the completion blocks
- */
-- (void)postTournamentScore:(NSString *)leaderboardId
-                      score:(int)score
-                   jsonData:(NSString *)jsonData
-           roundStartedTimeLocal:(NSDate *)roundStartedTimeLocal
-            completionBlock:(BCCompletionBlock)cb
-       errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                   cbObject:(BCCallbackObject)cbObject;
-
-/**
  * Post the users score to the leaderboard - UTC time
  *
  * Service Name - tournament
@@ -206,36 +184,6 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
             completionBlock:(BCCompletionBlock)cb
        errorCompletionBlock:(BCErrorCompletionBlock)ecb
                    cbObject:(BCCallbackObject)cbObject;
-/**
-* Post the users score to the leaderboard - LOCAL time
-*
-* Service Name - tournament
-* Service Operation - POST_TOURNAMENT_SCORE_WITH_RESULTS
-*
-* @param leaderboardId The leaderboard for the tournament
-* @param score The score to post
-* @param jsonData Optional data attached to the leaderboard entry
-* @param roundStartedTimeLocal Time the user started the match and is converted
-* @param sort Sort key Sort order of page.
-* @param beforeCount The count of number of players before the current player to include.
-* @param afterCount The count of number of players after the current player to include.
-* @param initialScore The initial score for players first joining a tournament
-*                         Usually 0, unless leaderboard is LOW_VALUE
-* @param completionBlock Block to call on return of successful server response
-* @param errorCompletionBlock Block to call on return of unsuccessful server response
-* @param cbObject User object sent to the completion blocks
-*/
-- (void)postTournamentScoreWithResults:(NSString *)leaderboardId
-                                 score:(int)score
-                              jsonData:(NSString *)jsonData
-                      roundStartedTimeLocal:(NSDate *)roundStartedTimeLocal
-                             sortOrder:(SortOrder)sortOrder
-                           beforeCount:(int)beforeCount
-                            afterCount:(int)afterCount
-                          initialScore:(int)initialScore
-                       completionBlock:(BCCompletionBlock)cb
-                  errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                              cbObject:(BCCallbackObject)cbObject;
 
 /**
 * Post the users score to the leaderboard - UTC time

--- a/Shared/BrainCloudTournament.mm
+++ b/Shared/BrainCloudTournament.mm
@@ -112,26 +112,6 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
     _client->getTournamentService()->leaveTournament(
         [leaderboardId UTF8String], new BrainCloudCallback(cb, ecb, cbObject));
 }
-/*
-    deprecated Use PostTournamentScoreUTC instead - Removal after september 1 2021
- */
-- (void)postTournamentScore:(NSString *)leaderboardId
-                      score:(int)score
-                   jsonData:(NSString *)jsonData
-           roundStartedTimeLocal:(NSDate *)roundStartedTime
-            completionBlock:(BCCompletionBlock)cb
-       errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                   cbObject:(BCCallbackObject)cbObject
-{
-    time_t time = [roundStartedTime timeIntervalSince1970];
-    struct tm *timeStruct = gmtime(&time);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-    _client->getTournamentService()->postTournamentScore(
-        [leaderboardId UTF8String], score, jsonData == nil ? "" : [jsonData UTF8String], timeStruct,
-        new BrainCloudCallback(cb, ecb, cbObject));
-#pragma diagnostic pop
-}
 
 - (void)postTournamentScoreUTC:(NSString *)leaderboardId
                       score:(int)score
@@ -145,31 +125,6 @@ errorCompletionBlock:(BCErrorCompletionBlock)ecb
     [leaderboardId UTF8String], score, jsonData == nil ? "" : [jsonData UTF8String], roundStartedTime,
     new BrainCloudCallback(cb, ecb, cbObject));
     
-}
-/*
-    deprecated Use PostTournamentScoreWithResultsUTC instead - Removal after september 1 2021
- */
-- (void)postTournamentScoreWithResults:(NSString *)leaderboardId
-                                 score:(int)score
-                              jsonData:(NSString *)jsonData
-                      roundStartedTimeLocal:(NSDate *)roundStartedTime
-                             sortOrder:(SortOrder)sortOrder
-                           beforeCount:(int)beforeCount
-                            afterCount:(int)afterCount
-                          initialScore:(int)initialScore
-                       completionBlock:(BCCompletionBlock)cb
-                  errorCompletionBlock:(BCErrorCompletionBlock)ecb
-                              cbObject:(BCCallbackObject)cbObject
-{
-    time_t time = [roundStartedTime timeIntervalSince1970];
-    struct tm *timeStruct = gmtime(&time);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated"
-    _client->getTournamentService()->postTournamentScoreWithResults(
-                                                                    [leaderboardId UTF8String], score, jsonData == nil ? "" : [jsonData UTF8String], timeStruct,
-                                                                    (BrainCloud::SortOrder)sortOrder, beforeCount, afterCount, initialScore,
-                                                                    new BrainCloudCallback(cb, ecb, cbObject));
-#pragma diagnostic pop
 }
 
 - (void)postTournamentScoreWithResultsUTC:(NSString *)leaderboardId

--- a/Shared/BrainCloudWrapper.hh
+++ b/Shared/BrainCloudWrapper.hh
@@ -33,17 +33,6 @@
 @property (nonatomic) BOOL alwaysAllowProfileSwitch;
 
 /**
- * Method returns a singleton instance of the BrainCloudWrapper.
- *
- * Note: if using a local instance of the brainCloud client, refer to it instead of getInstance.
- *
- * @return A singleton instance of the BrainCloudWrapper.
- *
- * @deprecated Use of the *singleton* has been deprecated. We recommend that you create your own *variable* to hold an instance of the brainCloudWrapper. Explanation here: http://getbraincloud.com/apidocs/wrappers-clients-and-inconvenient-singletons/
- */
-+ (BrainCloudWrapper *) getInstance;
-
-/**
  * Initializes the brainCloud Wrapper
  */
 - (instancetype) init;
@@ -54,15 +43,6 @@
  * @param wrapperName value used to differentiate saved wrapper data
  */
 - (instancetype) init: (NSString*) wrapperName;
-
-
-/**
- * Method returns a singleton instance of the BrainCloudClient.
- * @return A singleton instance of the BrainCloudClient.
- *
- * @deprecated Use of the *singleton* has been deprecated. We recommend that you create your own *variable* to hold an instance of the brainCloudWrapper. Explanation here: http://getbraincloud.com/apidocs/wrappers-clients-and-inconvenient-singletons/
- */
-+ (BrainCloudClient *) getBC;
 
 /**
  * Method returns an instance of the BrainCloudClient.

--- a/Shared/BrainCloudWrapper.m
+++ b/Shared/BrainCloudWrapper.m
@@ -38,25 +38,6 @@ NSString * const kPersistenceKeyProfileId          = @"profileId";
 
 #pragma mark - Getters & Setters
 
-static BrainCloudWrapper *sharedWrapper = nil;
-
-+ (BrainCloudWrapper *) getInstance
-{
-    NSAssert([BrainCloudClient getEnableSingletonMode], @"Singleton usage is disabled. If called by mistake, use your own variable that holds an instance of the bcWrapper/bcClient.");
-    
-    @synchronized(self) {
-        if(sharedWrapper == nil) {
-            sharedWrapper = [[self alloc] init];
-            
-            [sharedWrapper setupCallBacks];
-            
-            [BrainCloudClient setInstance:[sharedWrapper getBCClient]];
-        }
-    }
-
-    return sharedWrapper;
-}
-
 -(void) setupCallBacks
 {
     self.alwaysAllowProfileSwitch = YES;
@@ -118,11 +99,6 @@ static BrainCloudWrapper *sharedWrapper = nil;
     }
     
     return self;
-}
-
-+ (BrainCloudClient *) getBC
-{
-    return [[self getInstance] getBCClient];
 }
 
 - (BrainCloudClient *) getBCClient

--- a/Shared/ServiceOperation.hh
+++ b/Shared/ServiceOperation.hh
@@ -137,7 +137,6 @@ extern NSString const *const BrainCloudServiceOperationResetMilestones;
 extern NSString const *const BrainCloudServiceOperationReadCompletedMilestones;
 extern NSString const *const BrainCloudServiceOperationReadInProgressMilestones;
 extern NSString const *const BrainCloudServiceOperationLogout;
-extern NSString const *const BrainCloudServiceOperationUpdateName;
 extern NSString const *const BrainCloudServiceOperationStartMatch;
 extern NSString const *const BrainCloudServiceOperationCancelMatch;
 extern NSString const *const BrainCloudServiceOperationCompleteMatch;

--- a/Shared/ServiceOperation.hh
+++ b/Shared/ServiceOperation.hh
@@ -137,6 +137,7 @@ extern NSString const *const BrainCloudServiceOperationResetMilestones;
 extern NSString const *const BrainCloudServiceOperationReadCompletedMilestones;
 extern NSString const *const BrainCloudServiceOperationReadInProgressMilestones;
 extern NSString const *const BrainCloudServiceOperationLogout;
+extern NSString const *const BrainCloudServiceOperationUpdateUserName;
 extern NSString const *const BrainCloudServiceOperationStartMatch;
 extern NSString const *const BrainCloudServiceOperationCancelMatch;
 extern NSString const *const BrainCloudServiceOperationCompleteMatch;

--- a/Shared/ServiceOperation.mm
+++ b/Shared/ServiceOperation.mm
@@ -137,7 +137,6 @@ NSString const *const BrainCloudServiceOperationResetMilestones = [NSString stri
 NSString const *const BrainCloudServiceOperationReadCompletedMilestones = [NSString stringWithCString:BrainCloud::ServiceOperation::ReadCompletedMilestones.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationReadInProgressMilestones = [NSString stringWithCString:BrainCloud::ServiceOperation::ReadInProgressMilestones.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationLogout = [NSString stringWithCString:BrainCloud::ServiceOperation::Logout.getValue().c_str() encoding:NSASCIIStringEncoding];
-NSString const *const BrainCloudServiceOperationUpdateName = [NSString stringWithCString:BrainCloud::ServiceOperation::UpdateName.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationStartMatch = [NSString stringWithCString:BrainCloud::ServiceOperation::StartMatch.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationCancelMatch = [NSString stringWithCString:BrainCloud::ServiceOperation::CancelMatch.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationCompleteMatch = [NSString stringWithCString:BrainCloud::ServiceOperation::CompleteMatch.getValue().c_str() encoding:NSASCIIStringEncoding];

--- a/Shared/ServiceOperation.mm
+++ b/Shared/ServiceOperation.mm
@@ -137,6 +137,7 @@ NSString const *const BrainCloudServiceOperationResetMilestones = [NSString stri
 NSString const *const BrainCloudServiceOperationReadCompletedMilestones = [NSString stringWithCString:BrainCloud::ServiceOperation::ReadCompletedMilestones.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationReadInProgressMilestones = [NSString stringWithCString:BrainCloud::ServiceOperation::ReadInProgressMilestones.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationLogout = [NSString stringWithCString:BrainCloud::ServiceOperation::Logout.getValue().c_str() encoding:NSASCIIStringEncoding];
+NSString const *const BrainCloudServiceOperationUpdateUserName = [NSString stringWithCString:BrainCloud::ServiceOperation::UpdateUserName.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationStartMatch = [NSString stringWithCString:BrainCloud::ServiceOperation::StartMatch.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationCancelMatch = [NSString stringWithCString:BrainCloud::ServiceOperation::CancelMatch.getValue().c_str() encoding:NSASCIIStringEncoding];
 NSString const *const BrainCloudServiceOperationCompleteMatch = [NSString stringWithCString:BrainCloud::ServiceOperation::CompleteMatch.getValue().c_str() encoding:NSASCIIStringEncoding];

--- a/Tests/TestAppStore.m
+++ b/Tests/TestAppStore.m
@@ -26,12 +26,12 @@
 
 - (void)testCachePurchaseContext
 {
-    [[m_client appStoreService] cachePurchaseContext:@"invalid_storeId"
-                                               iapId:@"invalid_iapId"
-                                             payload:@"{}"
-                                     completionBlock:successBlock
-                                errorCompletionBlock:failureBlock
-                                            cbObject:nil];
+    [[m_client appStoreService] cachePurchasePayloadContext:@"invalid_storeId"
+                                                      iapId:@"invalid_iapId"
+                                                    payload:@"{}"
+                                            completionBlock:successBlock
+                                       errorCompletionBlock:failureBlock
+                                                   cbObject:nil];
     [self waitForFailedResult];
 }
 

--- a/Tests/TestAppStore.m
+++ b/Tests/TestAppStore.m
@@ -24,7 +24,7 @@
     [super tearDown];
 }
 
-- (void)testCachePurchaseContext
+- (void)testcachePurchasePayloadContext
 {
     [[m_client appStoreService] cachePurchasePayloadContext:@"invalid_storeId"
                                                       iapId:@"invalid_iapId"

--- a/Tests/TestLeaderboard.m
+++ b/Tests/TestLeaderboard.m
@@ -292,27 +292,6 @@ NSString *eventId = @"tournamentRewardTest";
     [self waitForResult];
 }
 
-- (void)testPostScoreToDynamicLeaderboard
-{
-    NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
-    dayComponent.day = 1;
-
-    NSCalendar *theCalendar = [NSCalendar currentCalendar];
-    NSDate *nextDate = [theCalendar dateByAddingComponents:dayComponent toDate:[NSDate date] options:0];
-
-    [[m_client leaderboardService] postScoreToDynamicLeaderboard:dynamicLeaderboardId
-                                                           score:100
-                                                        jsonData:@""
-                                                 leaderboardType:LOW_VALUE
-                                                    rotationType:WEEKLY
-                                                  roatationReset:nextDate
-                                                   retainedCount:2
-                                                 completionBlock:successBlock
-                                            errorCompletionBlock:failureBlock
-                                                        cbObject:nil];
-    [self waitForResult];
-}
-
 - (void)testPostScoreToDynamicLeaderboardUsingConfig
 {
     [[m_client leaderboardService] postScoreToDynamicLeaderboardUsingConfig:dynamicLeaderboardId
@@ -340,27 +319,6 @@ NSString *eventId = @"tournamentRewardTest";
                                                  completionBlock:successBlock
                                             errorCompletionBlock:failureBlock
                                                         cbObject:nil];
-    [self waitForResult];
-}
-- (void)testPostScoreToDynamicLeaderboardDays
-{
-    NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
-    dayComponent.day = 1;
-
-    NSCalendar *theCalendar = [NSCalendar currentCalendar];
-    NSDate *nextDate = [theCalendar dateByAddingComponents:dayComponent toDate:[NSDate date] options:0];
-    NSString *name = [NSString stringWithFormat:@"%@Days_%d", dynamicLeaderboardId, arc4random_uniform(1000000)];
-
-    [[m_client leaderboardService] postScoreToDynamicLeaderboardDays:name
-                                                               score:100
-                                                            jsonData:@""
-                                                     leaderboardType:LOW_VALUE
-                                                      roatationReset:nextDate
-                                                       retainedCount:2
-                                                     numDaysToRotate:3
-                                                     completionBlock:successBlock
-                                                errorCompletionBlock:failureBlock
-                                                            cbObject:nil];
     [self waitForResult];
 }
 
@@ -669,40 +627,6 @@ NSString *eventId = @"tournamentRewardTest";
                                                    completionBlock:successBlock
                                               errorCompletionBlock:failureBlock
                                                           cbObject:nil];
-    [self waitForResult];
-}
-
-- (void)testPostScoreToDynamicGroupLeaderboard
-{
-    [[m_client groupService] createGroup:@"testGroup"
-                               groupType:@"test"
-                             isOpenGroup:NO
-                                     acl:@""
-                                jsonData:@""
-                     jsonOwnerAttributes:@""
-             jsonDefaultMemberAttributes:@""
-                         completionBlock:successBlock
-                    errorCompletionBlock:failureBlock 
-                                cbObject:nil];
-    [self waitForResult];
-    
-    NSData *data = [self.jsonResponse dataUsingEncoding:NSUTF8StringEncoding];
-    NSDictionary *jsonObj =
-    [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:nil];
-    
-    NSString *groupId = [(NSDictionary *)[jsonObj objectForKey:@"data"] objectForKey:@"groupId"];
-    
-    [[m_client leaderboardService] postScoreToDynamicGroupLeaderboard:groupLeaderboardId
-                                                              groupId:groupId
-                                                                score:100
-                                                             jsonData:@""
-                                                      leaderboardType:@"HIGH_VALUE"
-                                                         rotationType:@"WEEKLY"
-                                                    rotationResetTime:15708182
-                                                        retainedCount:2
-                                               completionBlock:successBlock
-                                          errorCompletionBlock:failureBlock
-                                                      cbObject:nil];
     [self waitForResult];
 }
 

--- a/Tests/TestLeaderboard.m
+++ b/Tests/TestLeaderboard.m
@@ -92,7 +92,6 @@ NSString *eventId = @"tournamentRewardTest";
 - (void)testGetMultiSocialLeaderboard
 {
     [self testPostScoreToLeaderboard];
-    [self testPostScoreToDynamicLeaderboard];
     NSArray *lbIds = [NSArray arrayWithObjects:globalLeaderboardId, dynamicLeaderboardId, nil];
     [[m_client leaderboardService] getMultiSocialLeaderboard:lbIds
                                       leaderboardResultCount:10

--- a/Tests/TestPlayerState.m
+++ b/Tests/TestPlayerState.m
@@ -90,15 +90,6 @@
     [self waitForResult];
 }
 
-- (void)testUpdateName
-{
-    [[m_client playerStateService] updateName:@"TestName"
-                                  completionBlock:successBlock
-                             errorCompletionBlock:failureBlock
-                                         cbObject:nil];
-    [self waitForResult];
-}
-
 - (void)testUpdatePlayerPictureUrl
 {
     [[m_client playerStateService] updateUserPictureUrl:@"https://some.domain.com/mypicture.jpg"

--- a/Tests/TestScript.m
+++ b/Tests/TestScript.m
@@ -34,24 +34,6 @@ NSString *_parentLevelName = @"Master";
     [self waitForResult];
 }
 
-- (void)testScheduleScriptUTC
-{
-    NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
-    dayComponent.day = 1;
-
-    NSCalendar *theCalendar = [NSCalendar currentCalendar];
-    NSDate *nextDate =
-        [theCalendar dateByAddingComponents:dayComponent toDate:[NSDate date] options:0];
-
-    [[m_client scriptService] scheduleRunScriptUTC:scriptName
-                                    jsonScriptData:@""
-                                    startDateLocal:nextDate
-                                   completionBlock:successBlock
-                              errorCompletionBlock:failureBlock
-                                          cbObject:nil];
-    [self waitForResult];
-}
-
 - (void)testScheduleScriptMillisUTC
 {
         NSDate *now = [NSDate date];

--- a/Tests/TestTournament.m
+++ b/Tests/TestTournament.m
@@ -98,20 +98,6 @@ BOOL _didJoin = false;
     [self leaveTournament];
 }
 
-- (void)testPostTournamentScore
-{
-    [self joinTournament];
-
-    [[m_client tournamentService] postTournamentScore:_leaderboardId
-                                                score:200
-                                             jsonData:nil
-                                     roundStartedTimeLocal:[NSDate date]
-                                      completionBlock:successBlock
-                                 errorCompletionBlock:failureBlock
-                                             cbObject:nil];
-    [self waitForResult];
-}
-
 - (void)testPostTournamentScoreUTC
 {
     [self joinTournament];
@@ -126,23 +112,6 @@ BOOL _didJoin = false;
                                       completionBlock:successBlock
                                  errorCompletionBlock:failureBlock
                                              cbObject:nil];
-    [self waitForResult];
-}
-- (void)testPostTournamentScoreWithResults
-{
-    [self joinTournament];
-
-    [[m_client tournamentService] postTournamentScoreWithResults:_leaderboardId
-                                                           score:200
-                                                        jsonData:nil
-                                                roundStartedTimeLocal:[NSDate date]
-                                                       sortOrder:HIGH_TO_LOW
-                                                     beforeCount:10
-                                                      afterCount:10
-                                                    initialScore:0
-                                                 completionBlock:successBlock
-                                            errorCompletionBlock:failureBlock
-                                                        cbObject:nil];
     [self waitForResult];
 }
 


### PR DESCRIPTION
[BCLOUD-11096](https://bitheads.atlassian.net/browse/BCLOUD-11096)

Removed several API calls that were deemed deprecated and were to be removed after 2020. Well, it's after 2020 now! Tests related to deprecated functions have also been removed.

Also used this as an opportunity to rename `cachePurchaseContext` to `cachePurchasePayloadContext`.